### PR TITLE
Add getContent hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "broccoli-kitchen-sink-helpers": "^0.3.1",
     "broccoli-plugin": "^1.1.0",
     "mkdirp": "^0.5.1",
-    "rsvp": "^3.0.6",
+    "rsvp": "^3.3.2",
     "symlink-or-copy": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Allow subclasses to override how content is generated, and make it async, e.g.:

``` js
MyPlugin.prototype.getContent = function() {
  return new RSVP.Promise(function(resolve) {
    resolve('something else');
  });
}
```
